### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build-and-test:
+    name: Java CI/CD / build-and-test
     runs-on: ubuntu-latest
     env:
       MIN_COVERAGE: 80


### PR DESCRIPTION
Este PR define explicitamente o nome do job no workflow CI para evitar checks duplicados pendentes no GitHub Actions.
